### PR TITLE
fix crafting recipe collision with screwdriver-mod (minetest_game)

### DIFF
--- a/crafts.lua
+++ b/crafts.lua
@@ -142,8 +142,9 @@ minetest.register_craft({
 minetest.register_craft({
 	output = "xdecor:hammer",
 	recipe = {
-		{"default:steel_ingot"},
-		{"group:stick"}
+		{"default:steel_ingot","group:stick","default:steel_ingot"},
+		{"", "group:stick", ""},
+		{"", "group:stick", ""}
 	}
 })
 	


### PR DESCRIPTION
following recipe is registered for xdecor:hammer and screwdriver:screwdriver.

```
recipe = {
  {"default:steel_ingot"},
  {"group:stick"}
}
```

Most layman will use mods on combination with the minetest_game subgame, so imo there should be no collisions with mods from this subgame (unless there is a very good reason)

I changed it to

```
recipe = {`
  {"default:steel_ingot", "group:stick", "default:steel_ingot"},
  {"", "group:stick", ""},
  {"", "group:stick", ""}
}
```

so it look much more like a hammer and does not collide with mods from minetest_game.