### PR TITLE
bucket is required since 9f8a1ae

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,4 +1,4 @@
 default
 doors
 xpanes
-bucket?
+bucket


### PR DESCRIPTION
cauldron require buckets so the bucket mod is no longer optional